### PR TITLE
Don't render error message on front-end

### DIFF
--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -56,10 +56,11 @@ class Blocks {
 		$response = $jobber->get_form( $form_type );
 
 		if ( is_wp_error( $response ) ) {
-			return sprintf(
-				'<p class="jobber-error">%s</p>',
-				esc_html( $response->get_error_message() )
-			);
+			// if we encounter an error when rendering on the front-end,
+			// do not render anything instead of showing an error message,
+			// as the error message just confuses the actual user.
+			// see https://github.com/10up/jobber-wp/issues/10#issue-2993579619.
+			return '';
 		}
 
 		$iframe_url = '';

--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -56,7 +56,7 @@ class Blocks {
 		$response = $jobber->get_form( $form_type );
 
 		if ( is_wp_error( $response ) ) {
-			// if we encounter an error when rendering on the front-end,
+			// If we encounter an error when rendering on the front-end,
 			// do not render anything instead of showing an error message,
 			// as the error message just confuses the actual user.
 			// see https://github.com/10up/jobber-wp/issues/10#issue-2993579619.
@@ -78,7 +78,11 @@ class Blocks {
 		}
 
 		if ( empty( $iframe_url ) ) {
-			return '<p class="jobber-error">' . esc_html__( 'Form iframe URL not found.', 'jobber-wp' ) . '</p>';
+			// If no iframe URL is returned on the front-end,
+			// do not render anything instead of showing an error message,
+			// as the error message just confuses the actual user.
+			// see https://github.com/10up/jobber-wp/issues/10#issue-2993579619.
+			return '';
 		}
 
 		return sprintf(

--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -56,9 +56,9 @@ class Blocks {
 		$response = $jobber->get_form( $form_type );
 
 		if ( is_wp_error( $response ) ) {
-			// If we encounter an error when rendering on the front-end,
-			// do not render anything instead of showing an error message,
-			// as the error message just confuses the actual user.
+			// If we encounter an error return nothing
+			// instead of returning an error message since the
+			// end user can't do anything about the error.
 			// see https://github.com/10up/jobber-wp/issues/10#issue-2993579619.
 			return '';
 		}
@@ -78,9 +78,9 @@ class Blocks {
 		}
 
 		if ( empty( $iframe_url ) ) {
-			// If no iframe URL is returned on the front-end,
-			// do not render anything instead of showing an error message,
-			// as the error message just confuses the actual user.
+			// If no iframe URL is returned, return nothing
+			// instead of returning an error message since the
+			// end user can't do anything about the error.
 			// see https://github.com/10up/jobber-wp/issues/10#issue-2993579619.
 			return '';
 		}


### PR DESCRIPTION
### Description of the Change

This PR returns nothing when an error is encountered on the front-end to avoid user confusion.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #10

### How to test the Change

1. Add the Jobber form on the page.
2. Get disconnected WP from Jobber (maybe delete settings from the DB)
3. Try to see the form on the front end. Nothing should show.

### Changelog Entry

> Changed - Instead of showing error messages, show nothing on front-end

### Credits

Props @dkotter @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
