### PR TITLE
Use Embed Code instead of iframe at FE

### DIFF
--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -91,9 +91,20 @@ class Blocks {
 			wp_kses(
 				$embed_script,
 				[
-					'script' => [ 'src' => true ],
 					'div'    => [
+						'id'    => true,
 						'class' => true,
+					],
+					'script' => [
+						'src'       => true,
+						'vendor_id' => true,
+						'form_url'  => true,
+						'clienthub_id' => true,
+					],
+					'link'   => [
+						'rel'   => true,
+						'href'  => true,
+						'media' => true,
 					],
 				]
 			)

--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -64,22 +64,22 @@ class Blocks {
 			return '';
 		}
 
-		$iframe_url = '';
+		$embed_script = '';
 
 		if (
 			'request' === $form_type &&
-			isset( $response['data']['requestSettings']['requestUrl'] )
+			isset( $response['data']['requestSettings']['requestEmbedScript'] )
 		) {
-			$iframe_url = $response['data']['requestSettings']['requestUrl'];
+			$embed_script = $response['data']['requestSettings']['requestEmbedScript'];
 		} elseif (
 			'booking' === $form_type &&
-			isset( $response['data']['onlineBookingConfiguration']['bookingUrl'] )
+			isset( $response['data']['onlineBookingConfiguration']['bookingEmbedScript'] )
 		) {
-			$iframe_url = $response['data']['onlineBookingConfiguration']['bookingUrl'] . '/embedded';
+			$embed_script = $response['data']['onlineBookingConfiguration']['bookingEmbedScript'];
 		}
 
-		if ( empty( $iframe_url ) ) {
-			// If no iframe URL is returned, return nothing
+		if ( empty( $embed_script ) ) {
+			// If no iframe embed script is returned, return nothing
 			// instead of returning an error message since the
 			// end user can't do anything about the error.
 			// see https://github.com/10up/jobber-wp/issues/10#issue-2993579619.
@@ -87,9 +87,16 @@ class Blocks {
 		}
 
 		return sprintf(
-			'<div class="jobber-embed-block"><iframe src="%s" width="100%%" height="600" style="border:none;" title="%s"></iframe></div>',
-			esc_url( $iframe_url ),
-			esc_attr__( 'Jobber Form', 'jobber-wp' )
+			'<div class="jobber-embed-block">HEYYY!%s</div>',
+			wp_kses(
+				$embed_script,
+				[
+					'script' => [ 'src' => true ],
+					'div'    => [
+						'class' => true,
+					],
+				]
+			)
 		);
 	}
 }

--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -87,7 +87,7 @@ class Blocks {
 		}
 
 		return sprintf(
-			'<div class="jobber-embed-block">HEYYY!%s</div>',
+			'<div class="jobber-embed-block">%s</div>',
 			wp_kses(
 				$embed_script,
 				[

--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -96,9 +96,9 @@ class Blocks {
 						'class' => true,
 					],
 					'script' => [
-						'src'       => true,
-						'vendor_id' => true,
-						'form_url'  => true,
+						'src'          => true,
+						'vendor_id'    => true,
+						'form_url'     => true,
 						'clienthub_id' => true,
 					],
 					'link'   => [


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This update changes how the Jobber form is embedded on the frontend. Instead of using an iframe with fixed dimensions, it now loads dynamically using the official embed script, which automatically adjusts height and width for better responsiveness and display.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #24

### How to test the Change

1. Visit both the editor and frontend.
2. Confirm the Jobber forms render without any display or JS errors.
3. Ensure the embedded form adjusts its height/width responsively on the frontend.

### Changelog Entry

> Changed - Load Jobber form using embed code for responsive frontend display

### Credits

Props @dkotter @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
