### PR TITLE
Update iframe height based on form type

### DIFF
--- a/blocks/forms/edit.js
+++ b/blocks/forms/edit.js
@@ -103,7 +103,7 @@ const Edit = ({ attributes, setAttributes }) => {
 						src={iframeUrl}
 						style={{
 							border: '1px dashed #E0E0E0',
-							height: '500px',
+							height: formType === 'request' ? '1630px' : '600px',
 							width: '100%',
 						}}
 						title={__('Jobber Form', 'jobber')}

--- a/blocks/forms/edit.js
+++ b/blocks/forms/edit.js
@@ -103,7 +103,7 @@ const Edit = ({ attributes, setAttributes }) => {
 						src={iframeUrl}
 						style={{
 							border: '1px dashed #E0E0E0',
-							height: formType === 'request' ? '1630px' : '600px',
+							height: formType === 'request' ? '1630px' : '400px',
 							width: '100%',
 						}}
 						title={__('Jobber Form', 'jobber')}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

It was observed that the Request form requires a height of 1630 pixels, while the Booking form needs 600 pixels. This PR updates the block editor to apply these required heights accordingly.
Note: This change only affects the block editor view and does not impact the front-end display.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #42

### How to test the Change

1. Build the project
2. Visit the block editor
3. Confirm that the Jobber block displays the full-height form

### Changelog Entry

> Fixed - Request form content not fully visible in the block editor

### Credits

Props @ankitguptaindia @dkotter @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
