### PR TITLE
Ensure we always pull fresh data when making API requests in the admin

### DIFF
--- a/blocks/forms/edit.js
+++ b/blocks/forms/edit.js
@@ -35,7 +35,7 @@ const Edit = ({ attributes, setAttributes }) => {
 		setError(null);
 
 		apiFetch({
-			path: `jobber/v1/get_form?form_type=${formType}`,
+			path: `jobber/v1/get_form?form_type=${formType}&force=true`,
 			method: 'GET',
 		})
 			.then((response) => {

--- a/includes/classes/Jobber.php
+++ b/includes/classes/Jobber.php
@@ -134,9 +134,10 @@ class Jobber {
 	 * Get the form from Jobber.
 	 *
 	 * @param string $form_type The type of form to get. Default is 'request'.
+	 * @param bool   $force     Force a new request and bypass cache.
 	 * @return array|WP_Error
 	 */
-	public function get_form( string $form_type = 'request' ) {
+	public function get_form( string $form_type = 'request', bool $force = false ) {
 		if ( 'booking' === $form_type ) {
 			$form_type = 'booking';
 		} elseif ( 'request' === $form_type ) {
@@ -145,6 +146,6 @@ class Jobber {
 			return new WP_Error( 'jobber_invalid_form_type', __( 'Invalid form type.', 'jobber' ) );
 		}
 
-		return $this->query( $form_type );
+		return $this->query( $form_type, $force );
 	}
 }

--- a/includes/classes/REST/API.php
+++ b/includes/classes/REST/API.php
@@ -56,6 +56,10 @@ class API {
 						'type'     => 'string',
 						'required' => true,
 					],
+					'force'     => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
 				],
 			]
 		);
@@ -78,13 +82,14 @@ class API {
 	 */
 	public function get_form( \WP_REST_Request $request ) {
 		$form_type = $request->get_param( 'form_type' );
+		$force     = (bool) $request->get_param( 'force' );
 
 		if ( empty( $form_type ) ) {
 			$form_type = 'request';
 		}
 
 		$jobber = new \Jobber\Jobber();
-		$form   = $jobber->get_form( $form_type );
+		$form   = $jobber->get_form( $form_type, $force );
 
 		if ( is_wp_error( $form ) ) {
 			return rest_ensure_response( $form );

--- a/jobber.php
+++ b/jobber.php
@@ -16,7 +16,7 @@
  */
 
 // Useful global constants.
-define( 'JOBBER_PLUGIN_VERSION', '0.1.0' );
+define( 'JOBBER_PLUGIN_VERSION', '1.0.0' );
 define( 'JOBBER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'JOBBER_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'JOBBER_PLUGIN_INC', JOBBER_PLUGIN_PATH . 'includes/' );


### PR DESCRIPTION
### Description of the Change

We have caching around the API request we make to store that for 24 hours (or up to 24 hours to be accurate). We already have a mechanism in place to bypass that cache and this PR takes advantage of that to ensure we always get the most up-to-date data when an API request is made in the admin (in this case, the block editor).

### How to test the Change

Ensure the block renders properly in the admin

### Changelog Entry

> Changed - Always get fresh API data when rendering the block in the editor

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
