### PR TITLE
Disallow direct file access to plugin files

### DIFF
--- a/includes/classes/Admin/Settings.php
+++ b/includes/classes/Admin/Settings.php
@@ -7,13 +7,13 @@
 
 namespace Jobber\Admin;
 
-use Jobber\Module;
-use Jobber\Auth;
-use Jobber\REST\Token;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
+use Jobber\Module;
+use Jobber\Auth;
+use Jobber\REST\Token;
 
 /**
  * Base class for Jobber Configuration settings

--- a/includes/classes/Admin/Settings.php
+++ b/includes/classes/Admin/Settings.php
@@ -11,6 +11,10 @@ use Jobber\Module;
 use Jobber\Auth;
 use Jobber\REST\Token;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Base class for Jobber Configuration settings
  */

--- a/includes/classes/Auth.php
+++ b/includes/classes/Auth.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use Jobber\REST\Token;
 
 /**

--- a/includes/classes/Blocks.php
+++ b/includes/classes/Blocks.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use Jobber\Module;
 
 /**

--- a/includes/classes/Disconnect.php
+++ b/includes/classes/Disconnect.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use Jobber\Admin\Settings;
 
 /**

--- a/includes/classes/Jobber.php
+++ b/includes/classes/Jobber.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use Jobber\Module;
 use WP_Error;
 

--- a/includes/classes/Module.php
+++ b/includes/classes/Module.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Module is any feature that conditionally activates based on the current context.
  */

--- a/includes/classes/ModuleInitialization.php
+++ b/includes/classes/ModuleInitialization.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use ReflectionClass;
 use HaydenPierce\ClassFinder\ClassFinder;
 

--- a/includes/classes/ModuleInterface.php
+++ b/includes/classes/ModuleInterface.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Interface for the Module trait.
  */

--- a/includes/classes/REST/API.php
+++ b/includes/classes/REST/API.php
@@ -7,11 +7,11 @@
 
 namespace Jobber\REST;
 
-use Jobber\Module;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
+use Jobber\Module;
 
 /**
  * Jobber API Base

--- a/includes/classes/REST/API.php
+++ b/includes/classes/REST/API.php
@@ -9,6 +9,10 @@ namespace Jobber\REST;
 
 use Jobber\Module;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Jobber API Base
  */

--- a/includes/classes/REST/Token.php
+++ b/includes/classes/REST/Token.php
@@ -58,7 +58,7 @@ class Token extends API {
 			$this->validate( $token ) &&
 			! empty( $_GET['tokens'] )
 		) {
-			\Jobber\Admin\Settings::update_settings( [ 'authenticated' => true ] );
+			Settings::update_settings( [ 'authenticated' => true ] );
 		}
 		/* phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended */
 	}
@@ -125,7 +125,7 @@ class Token extends API {
 		}
 
 		// Check the nonce.
-		$settings = \Jobber\Admin\Settings::get_settings();
+		$settings = Settings::get_settings();
 		if ( empty( $settings['nonce'] ) ) {
 			return false;
 		}
@@ -223,7 +223,7 @@ class Token extends API {
 	 * @param string $token The token to save.
 	 */
 	public function save( $token ) {
-		\Jobber\Admin\Settings::update_settings( [ self::$key => $token ] );
+		Settings::update_settings( [ self::$key => $token ] );
 	}
 
 	/**
@@ -232,7 +232,7 @@ class Token extends API {
 	 * @return string
 	 */
 	public static function get_token(): string {
-		$settings = \Jobber\Admin\Settings::get_settings();
+		$settings = Settings::get_settings();
 		if ( empty( $settings[ self::$key ] ) ) {
 			return '';
 		}

--- a/includes/classes/REST/Token.php
+++ b/includes/classes/REST/Token.php
@@ -7,6 +7,10 @@
 
 namespace Jobber\REST;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use Jobber\Admin\Settings;
 use WP_REST_Server;
 use WP_REST_Request;

--- a/includes/core.php
+++ b/includes/core.php
@@ -7,6 +7,10 @@
 
 namespace Jobber\Core;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 use Jobber\ModuleInitialization;
 
 /**

--- a/includes/helpers/helpers.php
+++ b/includes/helpers/helpers.php
@@ -7,6 +7,10 @@
 
 namespace Jobber;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Get an initialized class by its full class name, including namespace.
  *

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -7,6 +7,10 @@
 
 namespace Jobber\Utility;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Get asset info from extracted asset files
  *

--- a/jobber.php
+++ b/jobber.php
@@ -15,6 +15,10 @@
  * @package Jobber
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 // Useful global constants.
 define( 'JOBBER_PLUGIN_VERSION', '1.0.0' );
 define( 'JOBBER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
### Description of the Change

Added a security check to all PHP files in the Jobber plugin that could be executed directly. This ensures that if the files are accessed outside of WordPress, they will immediately exit, following WordPress.org plugin security guidelines.

Closes #47

### How to test the Change

1. Attempt to access any PHP file in the Jobber plugin directly via the browser; the script should exit with no output.
2. Activate and use the plugin in WordPress to ensure normal functionality is unaffected.

### Changelog Entry

> Security - Added `ABSPATH` check to all executable PHP files to prevent direct access.

### Credits

Props @dkotter @faisal-alvi 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
