### PR TITLE
Better API error handling in the editor

### DIFF
--- a/blocks/forms/edit.js
+++ b/blocks/forms/edit.js
@@ -41,12 +41,14 @@ const Edit = ({ attributes, setAttributes }) => {
 			.then((response) => {
 				const url = response?.form?.iframeUrl;
 				if (!url) {
+					setIframeUrl('');
 					throw new Error(__('Form URL not found in API response', 'jobber'));
 				}
 				setIframeUrl(url);
 				setLoading(false);
 			})
 			.catch((err) => {
+				setIframeUrl('');
 				setError(err.message);
 				setLoading(false);
 			});


### PR DESCRIPTION
### Description of the Change

While testing an issue with scopes, noticed if I switched from one form type that worked to a form type that didn't in the editor, we end up showing both an error state and the original form, whereas we should only show the error state. This PR fixes that by clearing out the iframe URL when an error happens.

### How to test the Change

Not a great way to test. I found this because we changed scopes in our app and it broke the Booking form, while the Request form would still work. This has been addressed though so harder to reproduce this error state

### Changelog Entry

> Fixed - Better error handling when an API request fails.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
