### PR TITLE
Disconnect Jobber account when plugin is deactivated

### DIFF
--- a/includes/classes/Disconnect.php
+++ b/includes/classes/Disconnect.php
@@ -59,6 +59,9 @@ class Disconnect {
 			wp_die( esc_html__( 'Failed to disconnect from Jobber.', 'jobber' ) );
 		}
 
+		// Update the authenticated setting.
+		Settings::update_settings( [ 'authenticated' => false ] );
+
 		// Redirect to the settings page with the disconnected flag.
 		$redirect_url = add_query_arg(
 			[ self::ACTION => 'true' ],

--- a/includes/core.php
+++ b/includes/core.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Jobber\Jobber;
+use Jobber\Admin\Settings;
 use Jobber\ModuleInitialization;
 
 /**
@@ -75,6 +77,25 @@ function activate() {
 
 	// Set a transient to show the activation notice.
 	set_transient( 'jobber_activation_notice', 'jobber', HOUR_IN_SECONDS );
+}
+
+/**
+ * Deactivate the plugin.
+ */
+function deactivate() {
+	// Delete any transients.
+	delete_transient( 'jobber_activation_notice' );
+	foreach ( [ 'booking', 'request' ] as $form_type ) {
+		$cache_key = 'jobber_query_' . md5( wp_json_encode( [ 'query' => $form_type ] ) );
+		delete_transient( $cache_key );
+	}
+
+	// Send disconnect request to the middleware.
+	$disconnect = ( new Jobber() )->disconnect();
+	if ( ! $disconnect || is_wp_error( $disconnect ) ) {
+		// Update the authenticated setting.
+		Settings::update_settings( [ 'authenticated' => false ] );
+	}
 }
 
 /**

--- a/jobber.php
+++ b/jobber.php
@@ -55,5 +55,8 @@ require_once JOBBER_PLUGIN_INC . '/core.php';
 // Activation.
 register_activation_hook( __FILE__, '\Jobber\Core\activate' );
 
+// Deactivation.
+register_deactivation_hook( __FILE__, '\Jobber\Core\deactivate' );
+
 // Bootstrap.
 Jobber\Core\setup();


### PR DESCRIPTION
### Description of the Change

We currently have disconnect functionality in place that can be manually triggered from our settings page. But if someone connects their account and then deactivates the plugin, their site is technically still connected to Jobber.

This PR fixes that by adding a deactivation hook that will fire off the disconnect functionality.

Closes #50 

### How to test the Change

Because the disconnect functionality requires communication back and forth between the site and the middleware, this will only work if your site is publicly accessible (I tested locally using ngrok). If wanting to test the entire flow, follow the steps below:

1. Connect your site to Jobber
2. Go to your Jobber account and ensure the app is showing as connected: https://secure.getjobber.com/marketplace?nav_label=Apps&nav_source=sidebar
3. Deactivate the plugin
4. Ensure the app no longer shows as connected within your Jobber account

### Changelog Entry

> Added - Disconnect your Jobber account when the plugin is deactivated

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
