### PR TITLE
Fix PHPCS failure

### DIFF
--- a/includes/helpers/helpers.php
+++ b/includes/helpers/helpers.php
@@ -8,7 +8,7 @@
 namespace Jobber;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	return; // Return if accessed directly.
 }
 
 /**


### PR DESCRIPTION
### Description of the Change

Coming out of #48, our PHPCS workflow started to fail. The only thing changed in that PR was to avoid direct file access and in doing some research, it seems this can cause PHPCS to fail for files that are included via an autoloader. In our case, we include the `helpers.php` file in our autoloader and so we need to either remove the disallow direct access code or modify that to `return` instead of `exit`. For now, I've left that statement in and changed it to `return`.

### How to test the Change

Verify the PHPCS workflow passes now

### Changelog Entry

> Developer - Fix our PHPCS workflow.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
