### PR TITLE
Update copy on the settings page

### DIFF
--- a/includes/classes/Admin/Settings.php
+++ b/includes/classes/Admin/Settings.php
@@ -100,7 +100,7 @@ class Settings {
 							<?php
 							printf(
 								/* translators: %1$s: opening strong tag, %2$s: closing strong tag */
-								esc_html__( 'Click the %1$sConnect%2$s button below and log in with your Jobber account', 'jobber' ),
+								esc_html__( 'Click the %1$sConnect%2$s button below and log in with your Jobber account.', 'jobber' ),
 								'<strong>',
 								'</strong>'
 							);

--- a/includes/classes/Admin/Settings.php
+++ b/includes/classes/Admin/Settings.php
@@ -96,16 +96,36 @@ class Settings {
 						<?php esc_html_e( 'The Jobber plugin allows you to easily embed your Booking and Request forms using a new Jobber block. To get started, follow the steps below:', 'jobber' ); ?>
 					</p>
 					<ul style="list-style: decimal;">
-						<li style="margin-left: 2rem;"><?php esc_html_e( 'Click the Connect button below and log in with your Jobber account', 'jobber' ); ?></li>
-						<li style="margin-left: 2rem;"><?php esc_html_e( 'Edit the page where you want to embed your form and insert the Jobber block.', 'jobber' ); ?></li>
-						<li style="margin-left: 2rem;"><?php esc_html_e( 'Within the block settings, choose the form type, either Request or Booking.', 'jobber' ); ?></li>
+						<li style="margin-left: 2rem;">
+							<?php
+							printf(
+								/* translators: %1$s: opening strong tag, %2$s: closing strong tag */
+								esc_html__( 'Click the %1$sConnect%2$s button below and log in with your Jobber account', 'jobber' ),
+								'<strong>',
+								'</strong>'
+							);
+							?>
+						</li>
+						<li style="margin-left: 2rem;">
+							<?php esc_html_e( 'Edit the page where you want to embed your form and insert the Jobber block.', 'jobber' ); ?>
+						</li>
+						<li style="margin-left: 2rem;">
+							<?php
+							printf(
+								/* translators: %1$s: opening strong tag, %2$s: closing strong tag */
+								esc_html__( 'Open the %1$sBlock settings%2$s and select the form you want to embed: %1$sRequest%2$s or %1$sBooking%2$s.', 'jobber' ),
+								'<strong>',
+								'</strong>',
+							);
+							?>
+						</li>
 					</ul>
 					<p style="font-size: 14px; line-height: 1.7;">
 						<?php
 						printf(
 							/* translators: %1$s: opening link tag, %2$s: closing link tag */
-							esc_html__( 'If you don\'t have a Jobber account yet, follow %1$sthese%2$s instructions to create that first.', 'jobber' ),
-							'<a href="https://help.getjobber.com/hc/en-us/articles/360042653674-First-Steps-Basic-Account-Set-Up" target="_blank" rel="noreferrer noopener">',
+							esc_html__( 'Not using Jobber yet? Start your 14-day free trial and enjoy 20% off for six months—sign up %1$shere%2$s!', 'jobber' ),
+							'<a href="https://www.getjobber.com/plp/wordpress" target="_blank" rel="noreferrer noopener">',
 							'</a>'
 						);
 						?>
@@ -125,13 +145,35 @@ class Settings {
 					</p>
 					<p style="font-size: 14px; font-weight: 600;"><?php esc_html_e( 'Next steps:', 'jobber' ); ?></p>
 					<ul style="list-style: decimal;">
-						<li style="margin-left: 2rem;"><?php esc_html_e( 'Edit the page where you want to embed your form and insert the Jobber block.', 'jobber' ); ?></li>
-						<li style="margin-left: 2rem;"><?php esc_html_e( 'Within the block settings, choose the form type, either Request or Booking.', 'jobber' ); ?></li>
+						<li style="margin-left: 2rem;">
+							<?php esc_html_e( 'Edit the page where you want to embed your form and insert the Jobber block.', 'jobber' ); ?>
+						</li>
+						<li style="margin-left: 2rem;">
+							<?php
+							printf(
+								/* translators: %1$s: opening strong tag, %2$s: closing strong tag */
+								esc_html__( 'Open the %1$sBlock settings%2$s and select the form you want to embed: %1$sRequest%2$s or %1$sBooking%2$s.', 'jobber' ),
+								'<strong>',
+								'</strong>',
+							);
+							?>
+						</li>
 					</ul>
 
 					<p style="font-size: 14px; line-height: 1.7;">
-						<?php esc_html_e( 'If you no longer need to have a form embedded, you can disconnect your account by clicking the button below. Note that any existing forms you have embedded will no longer show.', 'jobber' ); ?>
+						<?php
+						printf(
+							/* translators: %1$s: opening strong tag, %2$s: closing strong tag */
+							esc_html__( 'To remove your embedded forms, click the %1$sDisconnect%2$s button below.', 'jobber' ),
+							'<strong>',
+							'</strong>',
+						);
+						?>
 					</p>
+					<p style="font-size: 14px; line-height: 1.7;">
+						<?php esc_html_e( 'This action will immediately disconnect your account, and every form you have previously embedded will disappear from your site. You can reconnect your account and re-embed forms at any time if you change your mind.', 'jobber' ); ?>
+					</p>
+
 					<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 						<?php wp_nonce_field( Disconnect::ACTION ); ?>
 						<input type="hidden" name="action" value="<?php echo esc_attr( Disconnect::ACTION ); ?>">

--- a/includes/classes/Admin/Settings.php
+++ b/includes/classes/Admin/Settings.php
@@ -124,7 +124,7 @@ class Settings {
 						<?php
 						printf(
 							/* translators: %1$s: opening link tag, %2$s: closing link tag */
-							esc_html__( 'Not using Jobber yet? Start your 14-day free trial and enjoy 20% off for six months—sign up %1$shere%2$s!', 'jobber' ),
+							esc_html__( 'Not using Jobber yet? Start your 14-day free trial and enjoy 20%% off for six months—sign up %1$shere%2$s!', 'jobber' ),
 							'<a href="https://www.getjobber.com/plp/wordpress" target="_blank" rel="noreferrer noopener">',
 							'</a>'
 						);

--- a/includes/core.php
+++ b/includes/core.php
@@ -128,7 +128,7 @@ function render_activation_notice() {
 				<img src="<?php echo esc_url( JOBBER_PLUGIN_URL . 'dist/images/jobber-logo.png' ); ?>" alt="<?php esc_attr_e( 'Jobber', 'jobber' ); ?>" style="max-width: 220px" />
 			</div>
 			<div class="jobber-activation-message" style="margin: 10px 0;">
-				<p><?php esc_html_e( 'Thanks for downloading the Jobber plugin.', 'jobber' ); ?></p>
+				<p><?php esc_html_e( 'Thanks for installing the Jobber plugin.', 'jobber' ); ?></p>
 				<p><?php esc_html_e( 'Connect your site to Jobber to get started.', 'jobber' ); ?></p>
 			</div>
 			<a class="button button-primary is-primary" href="<?php echo esc_url( admin_url( 'options-general.php?page=jobber_settings' ) ); ?>">


### PR DESCRIPTION
### Description of the Change

Minor updates to the plugin copy in the notice that shows after activating the plugin and on the settings page.

Closes #41

### How to test the Change

Verify all copy updates look good:

<img width="441" alt="Activation notice" src="https://github.com/user-attachments/assets/d66c8dfc-86ac-4bf1-8efd-009c5e775c76" />

<img width="670" alt=" connected settings page" src="https://github.com/user-attachments/assets/c595e48c-2277-4e16-9854-a5ba89724486" />

<img width="672" alt="Connected settings page" src="https://github.com/user-attachments/assets/d90a3e1f-3794-42f3-85ff-8653fc605967" />

### Changelog Entry

> Changed - Update plugin copy.

### Credits

Props @dkotter, @ankitguptaindia 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
