### PR TITLE
Validate the nonce before we set our authenticated state

### DIFF
--- a/includes/classes/REST/Token.php
+++ b/includes/classes/REST/Token.php
@@ -40,19 +40,26 @@ class Token extends API {
 	 */
 	public function register() {
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
-		add_action( 'init', [ $this, 'check_token' ] );
+		add_action( 'admin_init', [ $this, 'check_token' ] );
 	}
 
 	/**
-	 * Check for a valid authentication.
+	 * Check if our authentication request succeeded.
 	 */
 	public function check_token() {
-		/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended */
 		if ( ! isset( $_GET[ self::$key ] ) ) {
 			return;
 		}
 
-		// Make sure we have a valid token before saving.
+		// Make sure we have a valid user.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Verify the nonce.
+		check_admin_referer( 'jobber', 'nonce' );
+
+		// Ensure we have a valid token before updating the authenticated status.
 		$token = sanitize_text_field( wp_unslash( $_GET[ self::$key ] ) );
 
 		if (
@@ -61,7 +68,6 @@ class Token extends API {
 		) {
 			Settings::update_settings( [ 'authenticated' => true ] );
 		}
-		/* phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended */
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

More plugin review feedback was provided around needing a nonce check before we update our authenticated state to `true`. While we could probably argue our way around this, as we don't actually store any value sent in the URL, we just compare that value to what we already have stored to ensure they match (and thus don't really need a nonce check here), was easy enough to adjust the middleware to send back the initial nonce we give them and then verify that.

So this PR will rely on changes to the middleware (handled in a separate PR in that repo) to fully function.

In addition, changed our check to only fire in the admin and for administrators, which also reduces the scope of when this code is run.

> [!NOTE]  
> This PR is branched from the `plugin-submission` branch. This is to help keep a clean slate of what we have submitted to that team for review. We'll want to ensure the code changes here also get merged into `develop` after 

### How to test the Change

1. Checkout the corresponding middleware PR and set that up to run locally
2. Go through the authentication process in WordPress
3. Ensure you end up on a success screen and verify `authenticated = true` in the stored settings

### Changelog Entry

> Added - Verify our initial nonce before setting the authenticated state

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
