### PR TITLE
Validate the nonce before we set our authenticated state

### DIFF
--- a/includes/classes/REST/Token.php
+++ b/includes/classes/REST/Token.php
@@ -40,19 +40,26 @@ class Token extends API {
 	 */
 	public function register() {
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
-		add_action( 'init', [ $this, 'check_token' ] );
+		add_action( 'admin_init', [ $this, 'check_token' ] );
 	}
 
 	/**
-	 * Check for a valid authentication.
+	 * Check if our authentication request succeeded.
 	 */
 	public function check_token() {
-		/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended */
 		if ( ! isset( $_GET[ self::$key ] ) ) {
 			return;
 		}
 
-		// Make sure we have a valid token before saving.
+		// Make sure we have a valid user.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Verify the nonce.
+		check_admin_referer( 'jobber', 'nonce' );
+
+		// Ensure we have a valid token before updating the authenticated status.
 		$token = sanitize_text_field( wp_unslash( $_GET[ self::$key ] ) );
 
 		if (
@@ -61,7 +68,6 @@ class Token extends API {
 		) {
 			Settings::update_settings( [ 'authenticated' => true ] );
 		}
-		/* phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended */
 	}
 
 	/**

--- a/includes/core.php
+++ b/includes/core.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Jobber\Jobber;
+use Jobber\Auth;
 use Jobber\Admin\Settings;
 use Jobber\ModuleInitialization;
 
@@ -90,11 +91,13 @@ function deactivate() {
 		delete_transient( $cache_key );
 	}
 
-	// Send disconnect request to the middleware.
-	$disconnect = ( new Jobber() )->disconnect();
-	if ( ! $disconnect || is_wp_error( $disconnect ) ) {
-		// Update the authenticated setting.
-		Settings::update_settings( [ 'authenticated' => false ] );
+	// Send disconnect request to the middleware if we are authenticated.
+	if ( Auth::is_authorized() ) {
+		$disconnect = ( new Jobber() )->disconnect();
+		if ( ! $disconnect || is_wp_error( $disconnect ) ) {
+			// Update the authenticated setting if the disconnect fails.
+			Settings::update_settings( [ 'authenticated' => false ] );
+		}
 	}
 }
 


### PR DESCRIPTION
### Description of the Change

Brings changes from #54 over to `develop`.

Also added one minor adjustment to only send the disconnect request (that fires when the plugin is deactivated) if we are already authenticated. This way we don't try and disconnect if there's no need.

### How to test the Change

See #54 

### Changelog Entry

n/a

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
