### PR TITLE
More intelligent caching approach

### DIFF
--- a/includes/classes/Jobber.php
+++ b/includes/classes/Jobber.php
@@ -15,6 +15,8 @@ use Jobber\Module;
 use Jobber\REST\Token;
 use WP_Error;
 
+use function Jobber\Utility\get_cached_data;
+
 /**
  * Base class for Jobber API Connection
  */
@@ -138,10 +140,10 @@ class Jobber {
 
 		$data      = [ 'query' => $form_type ];
 		$cache_key = 'jobber_query_' . md5( wp_json_encode( $data ) );
-		$response  = get_transient( $cache_key );
+		$response  = get_cached_data( $cache_key, $force );
 
-		// If we have a cached response and we want to use it, return it.
-		if ( false !== $response && ! $force ) {
+		// If we have a cached response, return it.
+		if ( false !== $response ) {
 			return $response;
 		}
 

--- a/includes/classes/Jobber.php
+++ b/includes/classes/Jobber.php
@@ -16,6 +16,7 @@ use Jobber\REST\Token;
 use WP_Error;
 
 use function Jobber\Utility\get_cached_data;
+use function Jobber\Utility\set_cached_data;
 
 /**
  * Base class for Jobber API Connection
@@ -188,7 +189,7 @@ class Jobber {
 			return new WP_Error( 'jobber_graphql_error', implode( ' | ', $errors ) );
 		}
 
-		set_transient( $cache_key, $response, DAY_IN_SECONDS );
+		set_cached_data( $cache_key, $response );
 
 		return $response;
 	}

--- a/includes/classes/Jobber.php
+++ b/includes/classes/Jobber.php
@@ -59,6 +59,7 @@ class Jobber {
 	 * Register needed hooks.
 	 */
 	public function register() {
+		add_action( 'jobber_rebuild_cache', [ $this, 'rebuild_cache' ] );
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allow_jobber_redirect' ] );
 	}
 
@@ -84,6 +85,15 @@ class Jobber {
 	 */
 	public static function get_endpoint( string $path = 'jobber' ): string {
 		return self::get_api_url() . "/{$path}";
+	}
+
+	/**
+	 * Rebuild the cache.
+	 *
+	 * @param string $form_type The form type.
+	 */
+	public function rebuild_cache( string $form_type = '' ) {
+		$this->get_form( $form_type, true );
 	}
 
 	/**
@@ -141,7 +151,7 @@ class Jobber {
 
 		$data      = [ 'query' => $form_type ];
 		$cache_key = 'jobber_query_' . md5( wp_json_encode( $data ) );
-		$response  = get_cached_data( $cache_key, $force );
+		$response  = get_cached_data( $cache_key, $form_type, $force );
 
 		// If we have a cached response, return it.
 		if ( false !== $response ) {

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -109,3 +109,14 @@ function get_cached_data( string $key, bool $force = false ) {
 
 	return false;
 }
+
+/**
+ * Store cached data.
+ *
+ * @param string $key The cache key.
+ * @param mixed  $data The data to cache.
+ */
+function set_cached_data( string $key, $data ) {
+	set_transient( $key, $data, DAY_IN_SECONDS );
+	update_option( $key, $data );
+}

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -86,10 +86,11 @@ function style_url( string $stylesheet, string $context ): string {
  * Get cached data.
  *
  * @param string $key The cache key.
+ * @param string $form_type The form type.
  * @param bool   $force Whether to force a new request and bypass cache.
  * @return mixed The cached data or false if no data is found.
  */
-function get_cached_data( string $key, bool $force = false ) {
+function get_cached_data( string $key, string $form_type = '', bool $force = false ) {
 	// Always return false if we want to force a new request.
 	if ( $force ) {
 		return false;
@@ -103,6 +104,11 @@ function get_cached_data( string $key, bool $force = false ) {
 	} else {
 		// If we don't have a cached response, try to get it from the database.
 		$data = get_option( $key, false );
+
+		// If we have data here but not in cache, rebuild the cache.
+		if ( false !== $data && ! wp_next_scheduled( 'jobber_rebuild_cache', [ $form_type ] ) ) {
+			wp_schedule_single_event( time() + 1, 'jobber_rebuild_cache', [ $form_type ] );
+		}
 
 		return $data;
 	}

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -81,3 +81,31 @@ function style_url( string $stylesheet, string $context ): string {
 
 	return JOBBER_PLUGIN_URL . "dist/css/{$stylesheet}.css";
 }
+
+/**
+ * Get cached data.
+ *
+ * @param string $key The cache key.
+ * @param bool   $force Whether to force a new request and bypass cache.
+ * @return mixed The cached data or false if no data is found.
+ */
+function get_cached_data( string $key, bool $force = false ) {
+	// Always return false if we want to force a new request.
+	if ( $force ) {
+		return false;
+	}
+
+	$data = get_transient( $key );
+
+	// If we have a cached response, return it.
+	if ( false !== $data ) {
+		return $data;
+	} else {
+		// If we don't have a cached response, try to get it from the database.
+		$data = get_option( $key, false );
+
+		return $data;
+	}
+
+	return false;
+}

--- a/includes/utility.php
+++ b/includes/utility.php
@@ -108,6 +108,11 @@ function get_cached_data( string $key, string $form_type = '', bool $force = fal
 		// If we have data here but not in cache, rebuild the cache.
 		if ( false !== $data && ! wp_next_scheduled( 'jobber_rebuild_cache', [ $form_type ] ) ) {
 			wp_schedule_single_event( time() + 1, 'jobber_rebuild_cache', [ $form_type ] );
+
+			// Update the cache with the current data.
+			// This is to handle a situation where the API is down and
+			// rebuilding the cache won't work, leading to a loop of failed requests.
+			set_cached_data( $key, $data );
 		}
 
 		return $data;


### PR DESCRIPTION
### Description of the Change

Currently when an API request is made, we check if we have a stored value using transients and if so, return the cached value. If not, we make a fresh API request and then store that.

This approach works fine but does mean once the cache is expired, we'll have at least one front-end API request made (which can take a couple seconds). In addition, if the middleware ever goes down or Jobber's API goes down, we won't have data to use.

This PR makes a few adjustments to this approach. We add new helper methods to get cached data and store cached data. These methods use both transients and the options table, defaulting to transients first. If we have data cached in transients, we return that. If we don't, we check if we have data in the options table and return that. In addition, in that last scenario, we also schedule a single event that fires immediately and will rebuild the cache.

This approach should ensure we regularly are rebuilding the cache (ensuring we have fresh data) but we have data stored in the options table that we fallback to whenever needed, ensuring we always have something to render.

Closes #32 

### How to test the Change

1. Connect your site to Jobber
2. Ensure the Jobber block still renders as expected
3. If desired, inspect your database to ensure you see the transient and options stored there. Can also delete the transient and leave the option there to test that the scheduled event works

### Changelog Entry

> Changed - Better cache handling, ensuring we have fallback data to use

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
